### PR TITLE
fixes holopad renaming issues

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -20,7 +20,8 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Chat;
-using Content.Server._NF.Station.Systems; // Frontier
+using Content.Server._NF.Station.Systems;
+using Content.Server._Crescent.Holopad; // Frontier
 
 
 namespace Content.Server.Holopad;
@@ -39,6 +40,8 @@ public sealed class HolopadSystem : SharedHolopadSystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StationRenameHolopadsSystem _renameHolopads = default!; // Frontier
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
 
     private float _updateTimer = 1.0f;
 
@@ -816,13 +819,21 @@ public sealed class HolopadSystem : SharedHolopadSystem
             _ambientSoundSystem.SetAmbience(entity, isEnabled, ambientSound);
     }
 
-    // Frontier
-    # region Frontier Extensions
+    // Le... HullRotte Update!
+    #region Extensions
     private void OnHolopadMapInit(Entity<HolopadComponent> entity, ref MapInitEvent args)
     {
-        if (entity.Comp.UseStationName)
-            _renameHolopads.SyncHolopad(entity);
+        bool renameFromShipname = _entManager.HasComponent<ShipRenameHolopadComponent>(entity.Owner);
+
+        EntityUid? gridUid = null;
+        if (_entManager.TryGetComponent<TransformComponent>(entity.Owner, out var transform))
+        {
+            gridUid = transform.GridUid;
+        }
+
+        if (entity.Comp.UseStationName || renameFromShipname)
+            _renameHolopads.SyncHolopad(entity, forceit: renameFromShipname);
     }
     # endregion
-    // End Frontier
+    // Le... HullRotte Update!
 }

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -823,7 +823,6 @@ public sealed class HolopadSystem : SharedHolopadSystem
     #region Extensions
     private void OnHolopadMapInit(Entity<HolopadComponent> entity, ref MapInitEvent args)
     {
-
         bool renameFromShipname = false;
         EntityUid? gridUid = null;
         if (_entManager.TryGetComponent<TransformComponent>(entity.Owner, out var transform))
@@ -832,7 +831,6 @@ public sealed class HolopadSystem : SharedHolopadSystem
             renameFromShipname = _entManager.HasComponent<ShipRenameHolopadComponent>(gridUid);
         }
        
-
         if (entity.Comp.UseStationName || renameFromShipname)
             _renameHolopads.SyncHolopad(entity, forceit: renameFromShipname);
     }

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -823,13 +823,15 @@ public sealed class HolopadSystem : SharedHolopadSystem
     #region Extensions
     private void OnHolopadMapInit(Entity<HolopadComponent> entity, ref MapInitEvent args)
     {
-        bool renameFromShipname = _entManager.HasComponent<ShipRenameHolopadComponent>(entity.Owner);
 
+        bool renameFromShipname = false;
         EntityUid? gridUid = null;
         if (_entManager.TryGetComponent<TransformComponent>(entity.Owner, out var transform))
         {
             gridUid = transform.GridUid;
+            renameFromShipname = _entManager.HasComponent<ShipRenameHolopadComponent>(gridUid);
         }
+       
 
         if (entity.Comp.UseStationName || renameFromShipname)
             _renameHolopads.SyncHolopad(entity, forceit: renameFromShipname);

--- a/Content.Server/_Crescent/Holopad/ShipRenameHolopadComponent.cs
+++ b/Content.Server/_Crescent/Holopad/ShipRenameHolopadComponent.cs
@@ -1,0 +1,11 @@
+
+
+namespace Content.Server._Crescent.Holopad
+{
+    [RegisterComponent]
+    public sealed partial class ShipRenameHolopadComponent : Component
+    {
+
+
+    }
+}

--- a/Content.Server/_NF/Station/Systems/StationRenameHolopadsSystem.cs
+++ b/Content.Server/_NF/Station/Systems/StationRenameHolopadsSystem.cs
@@ -39,9 +39,9 @@ public sealed class StationRenameHolopadsSystem : EntitySystem
         }
     }
 
-    public void SyncHolopad(Entity<HolopadComponent> holopad, EntityUid? padStationUid = null)
+    public void SyncHolopad(Entity<HolopadComponent> holopad, EntityUid? padStationUid = null, bool forceit =  false)
     {
-        if (!holopad.Comp.UseStationName)
+        if (!holopad.Comp.UseStationName || forceit)
             return;
 
         padStationUid ??= _stationSystem.GetOwningStation(holopad);

--- a/Content.Shared/Holopad/HolopadComponent.cs
+++ b/Content.Shared/Holopad/HolopadComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class HolopadComponent : Component
     public float ControlLockoutCoolDown { get; private set; } = 180f;
 
     /// <summary>
-    /// Frontier - If true, will sync pad name with a station name.
+    /// Frontier - If true, will sync pad name with a station or SHIP name.
     /// </summary>
     [ViewVariables]
     [DataField]
@@ -77,6 +77,18 @@ public sealed partial class HolopadComponent : Component
     [ViewVariables]
     [DataField]
     public string? StationNameSuffix { get; set; } = null;
+
+
+    /// <summary>
+    /// Hullrot - allows renaming a holopad by ship- done automatically when component is initiatlized. yes with a typo. be a freethinker
+    /// </summary>
+    [ViewVariables]
+    [DataField]
+    public bool GetHolopadNameFromShip { get; set; }
+
+
+
+
 }
 
 #region: Event messages

--- a/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/termite.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/termite.yml
@@ -30,3 +30,4 @@
           overflowJobs: []
           availableJobs:
             Contractor: [ 1, 1 ]
+        - type: ShipRenameHolopad

--- a/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/termite.yml
+++ b/Resources/Prototypes/_Crescent/Maps/Ships/Civilian/termite.yml
@@ -30,4 +30,3 @@
           overflowJobs: []
           availableJobs:
             Contractor: [ 1, 1 ]
-        - type: ShipRenameHolopad

--- a/Resources/Prototypes/_Crescent/Maps/base.yml
+++ b/Resources/Prototypes/_Crescent/Maps/base.yml
@@ -12,6 +12,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+#    - type: ShipRenameHolopad # i assume not here because there could be multiple holopads
 
 - type: entity
   id: StandardCrescentOutpost #POI
@@ -26,6 +27,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: ShipRenameHolopad
 
 - type: entity
   id: StandardCrescentVessel #Combat vessel
@@ -41,6 +43,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: ShipRenameHolopad
 
 - type: entity
   id: StandardCrescentCivilianVessel #Civilian / unarmed vessel
@@ -56,6 +59,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: ShipRenameHolopad
 
 - type: entity
   id: StandardCrescentExpeditionVessel #Expeds
@@ -72,6 +76,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: ShipRenameHolopad
 
 - type: entity
   id: StandardCrescentExpeditionVesselCombat #Expeds
@@ -88,6 +93,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: Transform
+    - type: ShipRenameHolopad
 
 - type: entity
   id: BaseStationSiliconLawCrescentStation


### PR DESCRIPTION

# Description

## Fixes #23 - the holopad part of it

reuses the same functionality the UseStationName does to rename a grid's holopad.
but this works from the other end by simply adding a component to the grid instead of having to use a special holopad 
(and consequently remapping all the ships instead of adding a little line to each .yaml prototype)

still needs to test but it appears that the commands are not working very intuitively, though I've added the change to the Termite, if anyone can pull this on their end and check it out it would be quite Cool.

What it should do is cause the holopad of a termite to be named NZT-69 or w/e when called, this name change is initialized on the holopad object initializing itself (if the ship grid has the ShipRenameHolopadComponent)


---

# TODO

- [x ] add logic
- [] test
- [] add the component to every ship's grid 
---



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: thesoycoder
- fix: Fixed holopads not using ship names
