### PR TITLE
makes hardsuits replace footstep sounds properly

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -483,10 +483,21 @@ namespace Content.Shared.Movement.Systems
             }
             // Delta V NoShoesSilentFootsteps till here.
 
-            if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) &&
-                TryComp<FootstepModifierComponent>(shoes, out var modifier))
+
+            // If we have a clothing item with "FootstepModifier" on it, either on outer clothing (hardsuit) or on shoes (shoes), then change the sound. hardsuit takes priority.
+            // cuz it's above it and returns first. TryGetFootstepSound should still work for the cases where you have shoes but nothing that modifies.
+
+            if (_inventory.TryGetSlotEntity(uid, "outerClothing", out var hardsuit) &&
+                TryComp<FootstepModifierComponent>(hardsuit, out var modifier1))
             {
-                sound = modifier.FootstepSoundCollection;
+                sound = modifier1.FootstepSoundCollection;
+                return true; 
+            }
+
+            if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) &&
+                TryComp<FootstepModifierComponent>(shoes, out var modifier2))
+            {
+                sound = modifier2.FootstepSoundCollection;
                 return true;
             }
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -130,6 +130,9 @@
   id: ClothingOuterHardsuitBase
   name: base hardsuit
   components:
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepHardsuitLight
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
@@ -205,14 +208,6 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepHardsuitLight
-      params:
-        volume: -5
-    requiresWorn: true
-    distanceWalking: 2
-    distanceSprinting: 3
   - type: Reflect
     spread: 270
     reflectProb: 0.03
@@ -227,14 +222,9 @@
   id: ClothingOuterHardsuitBaseMedium
   name: base hardsuit
   components:
-  - type: EmitsSoundOnMove
-    soundCollection:
+  - type: FootstepModifier
+    footstepSoundCollection:
       collection: FootstepHardsuitMedium
-      params:
-        volume: -5
-    requiresWorn: true
-    distanceWalking: 2
-    distanceSprinting: 3
   - type: Fixtures
     fixtures:
       fix1:
@@ -270,14 +260,9 @@
   id: ClothingOuterHardsuitBaseHeavy
   name: base hardsuit
   components:
-  - type: EmitsSoundOnMove
-    soundCollection:
+  - type: FootstepModifier
+    footstepSoundCollection:
       collection: FootstepHardsuitHeavy
-      params:
-        volume: -5
-    requiresWorn: true
-    distanceWalking: 2
-    distanceSprinting: 3
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
currently, hardsuits use the "EmitsSoundOnMove" component to add their footstep sounds, which makes 2 footstep sounds on top of the normal (or even barefoot) footstep sound. 

this changes the base hardsuit prototypes to have a "FootstepModifier" component instead, and changes the SharedMoverController system to account for FootstepModifier components on outerClothing slots instead of just shoes.

https://github.com/user-attachments/assets/0fdeaec2-c780-488e-be18-646468baae9a

