### PR TITLE
Crash fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -21,14 +21,6 @@
     price: 1
 
 - type: entity
-  id: CartridgeHeavyRifle
-  name: cartridge (12.7×99mm USM)
-  parent: BaseCartridgeHeavyRifle
-  components:
-  - type: CartridgeAmmo
-    proto: BulletHeavyRifle
-
-- type: entity
   id: CartridgeMinigun
   name: cartridge (.10 rifle)
   parent: BaseCartridgeHeavyRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -35,7 +35,7 @@
 
 - type: entity
   id: BulletLightRifleIncendiary
-  parent: BaseBulletIncend
+  parent: BaseBulletIncendiary
   name: bullet (.5.56x45mm Imperial dragon's breath)
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
in light_rifle.yml there was BaseBulletIncend instead of BaseBulletIncendiary

and the heavy rifle cartridge was declared twice. deleted the declaration that wasn't in /_Crescent/ and it worked