### PR TITLE
added descriptions to biomes with really shit code

### DIFF
--- a/Content.Client/_Crescent/SpaceBiomes/SpaceBiomeSystem.cs
+++ b/Content.Client/_Crescent/SpaceBiomes/SpaceBiomeSystem.cs
@@ -27,8 +27,14 @@ public sealed class SpaceBiomeSystem : EntitySystem
         _audioSys.DisableAmbientMusic();
         SpaceBiomePrototype biome = _protMan.Index<SpaceBiomePrototype>(ev.Biome);
         _overlay.Reset();
+        _overlay.ResetDescription();
         _overlay.Text = biome.Name;
+        _overlay.TextDescription = biome.Description;
         _overlay.CharInterval = TimeSpan.FromSeconds(2f / biome.Name.Length);
+        if (_overlay.TextDescription == "")                   //if we have a biome with no description, it's default is "" and that has length 0.
+            _overlay.CharIntervalDescription = TimeSpan.Zero;       //we need to calculate it here because otherwise...
+        else
+            _overlay.CharIntervalDescription = TimeSpan.FromSeconds(2f / biome.Description.Length);      //this would throw an exception
     }
 
     private void OnNewVesselEntered(NewVesselEnteredMessage ev)
@@ -37,6 +43,8 @@ public sealed class SpaceBiomeSystem : EntitySystem
             return;
 
         _overlay.Text = ev.Name + ", " + ev.Designation;
+        _overlay.TextDescription = "A metal coffin."; //this can be changed to "" or updated later to change based on ship
         _overlay.CharInterval = TimeSpan.FromSeconds(2f / _overlay.Text.Length);
+        _overlay.CharIntervalDescription = TimeSpan.FromSeconds(2f / _overlay.TextDescription.Length);
     }
 }

--- a/Content.Shared/_Crescent/SpaceBiomes/SpaceBiomePrototype.cs
+++ b/Content.Shared/_Crescent/SpaceBiomes/SpaceBiomePrototype.cs
@@ -14,6 +14,9 @@ public sealed class SpaceBiomePrototype : IPrototype
     [DataField(required: true)]
     public string Name = "";
 
+    [DataField(required: false)]
+    public string Description = "";
+
     /// <summary>
     /// Time of interpolation between current parallax and a new one in seconds
     /// Does not include time to load new parallax textures

--- a/Resources/Prototypes/_Crescent/World/space_biomes.yml
+++ b/Resources/Prototypes/_Crescent/World/space_biomes.yml
@@ -6,11 +6,6 @@
   parallax: AbyssParallax
 
 #example
-- type: crescentFactionBiome
-  id: test
-  name: Test zone
-  swapDuration: 2
-  parallax: Sky
 
 - type: entity
   id: TestBiomeSource
@@ -21,13 +16,14 @@
     swapDistance: 1000
     priority: 1500
 
-#imperial
-
 - type: crescentFactionBiome
-  id: imperialbiome
-  name: Low Imperial Orbit
+  id: test
+  name: Test zone
   swapDuration: 2
   parallax: Sky
+  description: A zone of ample tests.
+
+#imperial
 
 - type: entity
   id: ImperialBiomeSource
@@ -37,6 +33,12 @@
     biome: imperialbiome
     swapDistance: 750
     priority: 2550
+
+- type: crescentFactionBiome
+  id: imperialbiome
+  name: Low Imperial Orbit
+  swapDuration: 2
+  parallax: Sky
 
 #hunter
 
@@ -190,6 +192,7 @@
   name: The Fracture
   swapDuration: 2
   parallax: Rupture
+  description: "The remnants of Taypan I."
 
 
 # breach


### PR DESCRIPTION
this adds descriptions (smaller font, gray text) under the titles for biomes and for ships. for now this adds text to The Fracture and to ships for testing purposes.

biomes are configured in the space_biomes.yml with a description tag

ship text is currently configured in SpaceBiomeSystem.cs FOR NOW. a different pr will be made to add text to individual ships (if you want this text gone just put "" instead of the text i left)

https://github.com/user-attachments/assets/4c6dd890-9204-4531-80ac-6195a7397a80

https://github.com/user-attachments/assets/87cf7eaf-28c0-4a99-b66a-2d89303f0732




how i did it:
in the Draw method for SpaceBiomeTextOverlay, i made it ALSO call DrawDescription which is almost a carbon copy of the regular Draw method but with different variables, and a different calculation for the position of the text. this looks ugly and the better idea would be to modify the function that actually calls Draw to call it twice and do the description, but i could not figure that out for the life of me.


