### PR TITLE
nukes almost every instance of EmitsSoundOnMove (modsuits replaced with FootstepModifier)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -509,13 +509,6 @@
           - SmokeOnTrigger
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]
@@ -597,13 +590,6 @@
   - type: Storage
     grid:
     - 0,0,3,1
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltStorageBase
@@ -626,13 +612,6 @@
         - Gun
         - BallisticAmmoProvider
         - CartridgeAmmo
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltSecurity
@@ -644,13 +623,6 @@
     sprite: Clothing/Belt/securitywebbing.rsi
   - type: Clothing
     sprite: Clothing/Belt/securitywebbing.rsi
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltSecurityWebbing
@@ -676,13 +648,6 @@
     sprite: Clothing/Belt/mercwebbing.rsi
   - type: Clothing
     sprite: Clothing/Belt/mercwebbing.rsi
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltStorageBase
@@ -694,13 +659,6 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
   - type: Clothing
     sprite: Clothing/Belt/salvagewebbing.rsi
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
@@ -714,13 +672,6 @@
     sprite: Clothing/Belt/militarywebbing.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltMilitaryWebbing
@@ -736,13 +687,6 @@
     size: Huge
   - type: ExplosionResistance
     damageCoefficient: 0.1
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3
 
 - type: entity
   parent: ClothingBeltBase

--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/Modsuits/legionnaire.yml
@@ -99,14 +99,9 @@
       coefficient: 0.01
     - type: StaminaDamageResistance
       coefficient: 0.5
-    - type: EmitsSoundOnMove
-      soundCollection:
+    - type: FootstepModifier
+      footstepSoundCollection:
         collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/belts.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/BieselRepublic/belts.yml
@@ -9,10 +9,3 @@
     sprite: _EE/Clothing/BieselRepublic/Belt/TCAF_webbing.rsi
   - type: Clothing
     sprite: _EE/Clothing/BieselRepublic/Belt/TCAF_webbing.rsi
-  - type: EmitsSoundOnMove
-    soundCollection:
-      collection: FootstepTacticalWebbing
-      params:
-        volume: -10
-    distanceWalking: 2
-    distanceSprinting: 3

--- a/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
+++ b/Resources/Prototypes/_EE/Entities/Clothing/SolAlliance/SAN/Modsuits/CSA-85x.yml
@@ -91,14 +91,9 @@
       coefficient: 0.01
     - type: StaminaDamageResistance
       coefficient: 0.5
-    - type: EmitsSoundOnMove
-      soundCollection:
+    - type: FootstepModifier
+      footstepSoundCollection:
         collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
 
 - type: entity
   parent: [ClothingModsuitBootsStandard, SolAllianceInfo]

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/apocryphal.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/apocryphal.yml
@@ -119,14 +119,9 @@
           Heat: 0.1
           Radiation: 0.1
           Caustic: 0.1
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/corporate.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/corporate.yml
@@ -117,14 +117,9 @@
           Heat: 0.1
           Radiation: 0.1
           Caustic: 0.1
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/engineering-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/engineering-responsory.yml
@@ -113,14 +113,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/inquisitory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/inquisitory.yml
@@ -111,14 +111,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/janitorial-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/janitorial-responsory.yml
@@ -113,14 +113,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/leader-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/leader-responsory.yml
@@ -113,14 +113,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/medical-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/medical-responsory.yml
@@ -113,14 +113,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/praetorian.yml
@@ -109,14 +109,9 @@
           Radiation: 0.5
           Heat: 0.5
           Caustic: 0.6
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/security-responsory.yml
+++ b/Resources/Prototypes/_EE/Entities/NanoTrasen/Modsuits/security-responsory.yml
@@ -113,14 +113,9 @@
           Heat: 0.5
           Radiation: 0.25
           Caustic: 0.4
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:

--- a/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
+++ b/Resources/Prototypes/_TG/Entities/Clothing/Modsuits/SyndicateModsuits.yml
@@ -105,14 +105,9 @@
     - type: Reflect
       spread: 270
       reflectProb: 0.04
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -5
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:
@@ -248,14 +243,9 @@
     - type: Reflect
       spread: 270
       reflectProb: 0.2
-    - type: EmitsSoundOnMove
-      soundCollection:
-        collection: FootstepHardsuitMedium
-        params:
-          volume: -7
-      requiresWorn: true
-      distanceWalking: 2
-      distanceSprinting: 3
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepHardsuitLight
     - type: SealableClothingVisuals
       visualLayers:
         outerClothing:


### PR DESCRIPTION
in a previous pr i made it so that hardsuits dont use this component anymore and use FootstepModifier to replace foosteps instead of **adding two additional sounds on top of the regular footstep**. this currently affects webbings the worst in rebase because they make this godawful loud sound which plays every damn footstep. equipment alternatives such as regular belts and drop pouches have almost identical functionality but without demolishing your ears

on BELTS: removed the component
on MODSUITS/OTHERS: replaced with FootstepModifier
on JESTER BELLS/WEIRD CYBERSUN STEALTH SUIT: left alone


https://github.com/user-attachments/assets/19fabe7a-c43a-47d0-b041-8fbc7e54d600

