### PR TITLE
Adds the DSM ornamental noble melees and all hullrot backpacks to their respective factions available in the loadout system

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/backpackGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/backpackGroups.yml
@@ -17,3 +17,37 @@
       id: LoadoutBackpackSatchelPurse
     - type: loadout
       id: LoadoutBackpackSatchelPurseFlipped
+#Hullrot edit start
+    - type: loadout
+      id: LoadoutBackpackNCWL
+    - type: loadout
+      id: LoadoutBackpackNCWLSatchel
+    - type: loadout
+      id: LoadoutBackpackNCWLDuffel
+    - type: loadout
+      id: LoadoutBackpackTFSC
+    - type: loadout
+      id: LoadoutBackpackTFSCSatchel
+    - type: loadout
+      id: LoadoutBackpackTFSCDuffel
+    - type: loadout
+      id: LoadoutBackpackDSM
+    - type: loadout
+      id: LoadoutBackpackDSMSatchel
+    - type: loadout
+      id: LoadoutBackpackSRM
+    - type: loadout
+      id: LoadoutBackpackSRMSatchel
+    - type: loadout
+      id: LoadoutBackpackSHI
+    - type: loadout
+      id: LoadoutBackpackSHISatchel
+    - type: loadout
+      id: LoadoutBackpackSHIDuffel
+    - type: loadout
+      id: LoadoutBackpackCMM
+    - type: loadout
+      id: LoadoutBackpackCMMSatchel
+    - type: loadout
+      id: LoadoutBackpackCMMDuffel
+#Hullrot edit end

--- a/Resources/Prototypes/CharacterItemGroups/Generic/beltGroup.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/beltGroup.yml
@@ -17,3 +17,9 @@
       id: LoadoutBeltWaistbagColor
     - type: loadout
       id: ClothingBeltTCAFWebbing
+    #Hullrot edit - EVERYTHING HULLROT RELATED DOWN HERE SEPERATED FROM UPSTREAM OR THE HUNTERS WILL COME AND GET YOU
+    - type: loadout
+      id: LoadoutBeltSheathDSMSabre
+    - type: loadout
+      id: LoadoutBeltSheathDSMRapier
+    #Hullrot edit end

--- a/Resources/Prototypes/_Crescent/CharacterItemGroups/Jobs/Empire/noble.yml
+++ b/Resources/Prototypes/_Crescent/CharacterItemGroups/Jobs/Empire/noble.yml
@@ -1,0 +1,8 @@
+- type: characterItemGroup
+  id: LoadoutDSMNobleWeapon
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutItemDSMSabre
+    - type: loadout
+      id: LoadoutItemDSMRapier

--- a/Resources/Prototypes/_Crescent/Loadouts/Back/backpacks.yml
+++ b/Resources/Prototypes/_Crescent/Loadouts/Back/backpacks.yml
@@ -1,0 +1,387 @@
+- type: loadout
+  id: LoadoutBackpackNCWL
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackNCWL
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdministratorNCWL
+        - ArtificerNCWL
+        - DoktorNCWL
+        - KadetNCWL
+        - KapitanNCWL
+        - KommissarNCWL
+        - SanitarNCWL
+
+- type: loadout
+  id: LoadoutBackpackNCWLSatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSatchelNCWL
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdministratorNCWL
+        - ArtificerNCWL
+        - DoktorNCWL
+        - KadetNCWL
+        - KapitanNCWL
+        - KommissarNCWL
+        - SanitarNCWL
+
+- type: loadout
+  id: LoadoutBackpackNCWLDuffel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDuffelNCWL
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdministratorNCWL
+        - ArtificerNCWL
+        - DoktorNCWL
+        - KadetNCWL
+        - KapitanNCWL
+        - KommissarNCWL
+        - SanitarNCWL
+
+- type: loadout
+  id: LoadoutBackpackTFSC
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackNCSP
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChemcookNCSP
+        - ForemanNCSP
+        - InfanteerNCSP
+        - IntelligenceOfficerNCSP
+        - LieutenantNCSP
+        - OperativeNCSP
+        - CyberdawnTechNCSP
+        - RingleaderNCSP
+        - RipperdocNCSP
+        - ShipbreakerNCSP
+        - TechnicianNCSP
+
+- type: loadout
+  id: LoadoutBackpackTFSCSatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackNCSPSatchel
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChemcookNCSP
+        - ForemanNCSP
+        - InfanteerNCSP
+        - IntelligenceOfficerNCSP
+        - LieutenantNCSP
+        - OperativeNCSP
+        - CyberdawnTechNCSP
+        - RingleaderNCSP
+        - RipperdocNCSP
+        - ShipbreakerNCSP
+        - TechnicianNCSP
+
+- type: loadout
+  id: LoadoutBackpackTFSCDuffel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackNCSPDuffelbag
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChemcookNCSP
+        - ForemanNCSP
+        - InfanteerNCSP
+        - IntelligenceOfficerNCSP
+        - LieutenantNCSP
+        - OperativeNCSP
+        - CyberdawnTechNCSP
+        - RingleaderNCSP
+        - RipperdocNCSP
+        - ShipbreakerNCSP
+        - TechnicianNCSP
+
+- type: loadout
+  id: LoadoutBackpackDSM
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDSM
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - ForemanDSM
+        - FreeholderDSM
+        - GovernorDSM
+        - KnightDSM
+        - LevymanDSM
+        - CourtierDSM
+        - ScribeDSM
+        - SurgeonDSM
+        - TemplarDSM
+        - WealthDSM
+
+- type: loadout
+  id: LoadoutBackpackDSMSatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDSMSatchel
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - ForemanDSM
+        - FreeholderDSM
+        - GovernorDSM
+        - KnightDSM
+        - LevymanDSM
+        - CourtierDSM
+        - ScribeDSM
+        - SurgeonDSM
+        - TemplarDSM
+        - WealthDSM
+
+- type: loadout
+  id: LoadoutBackpackSRM
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSRM
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AcolyteSRM
+        - HunterSRM
+        - MontagneSRM
+        - OverseerSRM
+        - TenderSRM
+
+- type: loadout
+  id: LoadoutBackpackSRMSatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSRMSatchel
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - AcolyteSRM
+        - HunterSRM
+        - MontagneSRM
+        - OverseerSRM
+        - TenderSRM
+
+- type: loadout
+  id: LoadoutBackpackSHI
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSHI
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - BoardSHI
+        - EmployeeSHI
+        - ExecutiveSHI
+        - HighsecSHI
+        - MedtechSHI
+        - CorpsecSHI
+        - KanoneerATH
+        - KommandantATH
+        - LeutnantATH
+        - SanitatATH
+        - SoldatATH
+        - AcolyteTAP
+        - Antiquarian
+        - BeltrunnerTAP
+        - DraugrTAP
+        - HangarTechTAP
+        - ProphetTAP
+        - ServileTAP
+        - TechminerTAP
+        - TinkererTAP
+        - Spacer
+        - GliessianDockmaster
+        - GliessianSheriff
+
+- type: loadout
+  id: LoadoutBackpackSHISatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSHISatchel
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - BoardSHI
+        - EmployeeSHI
+        - ExecutiveSHI
+        - HighsecSHI
+        - MedtechSHI
+        - CorpsecSHI
+        - KanoneerATH
+        - KommandantATH
+        - LeutnantATH
+        - SanitatATH
+        - SoldatATH
+        - AcolyteTAP
+        - Antiquarian
+        - BeltrunnerTAP
+        - DraugrTAP
+        - HangarTechTAP
+        - ProphetTAP
+        - ServileTAP
+        - TechminerTAP
+        - TinkererTAP
+        - Spacer
+        - GliessianDockmaster
+        - GliessianSheriff
+
+- type: loadout
+  id: LoadoutBackpackSHIDuffel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSHIDuffelbag
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - BoardSHI
+        - EmployeeSHI
+        - ExecutiveSHI
+        - HighsecSHI
+        - MedtechSHI
+        - CorpsecSHI
+        - KanoneerATH
+        - KommandantATH
+        - LeutnantATH
+        - SanitatATH
+        - SoldatATH
+        - AcolyteTAP
+        - Antiquarian
+        - BeltrunnerTAP
+        - DraugrTAP
+        - HangarTechTAP
+        - ProphetTAP
+        - ServileTAP
+        - TechminerTAP
+        - TinkererTAP
+        - Spacer
+        - GliessianDockmaster
+        - GliessianSheriff
+
+- type: loadout
+  id: LoadoutBackpackCMM
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackMinuteman
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - PhysicianCMM
+        - DeputyMarshalCMM
+        - MachinistCMM
+        - MarshalCMM
+        - MinutemanCMM
+        - OrdnancemanCMM
+        - WatchmasterCMM
+
+- type: loadout
+  id: LoadoutBackpackCMMSatchel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackMinutemanSatchel
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - PhysicianCMM
+        - DeputyMarshalCMM
+        - MachinistCMM
+        - MarshalCMM
+        - MinutemanCMM
+        - OrdnancemanCMM
+        - WatchmasterCMM
+
+- type: loadout
+  id: LoadoutBackpackCMMDuffel
+  category: Backpacks
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackMinutemanDuffelbag
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBackpacks
+    - !type:CharacterJobRequirement
+      jobs:
+        - PhysicianCMM
+        - DeputyMarshalCMM
+        - MachinistCMM
+        - MarshalCMM
+        - MinutemanCMM
+        - OrdnancemanCMM
+        - WatchmasterCMM

--- a/Resources/Prototypes/_Crescent/Loadouts/Empire/belt.yml
+++ b/Resources/Prototypes/_Crescent/Loadouts/Empire/belt.yml
@@ -1,0 +1,39 @@
+- type: loadout
+  id: LoadoutBeltSheathDSMSabre
+  category: Belt
+  cost: 0
+  items:
+    - ClothingBeltSheathDSMSabre
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - GovernorDSM
+        - KnightDSM
+        - CourtierDSM
+        - TemplarDSM
+        - WealthDSM
+
+- type: loadout
+  id: LoadoutBeltSheathDSMRapier
+  category: Belt
+  cost: 0
+  items:
+    - ClothingBeltSheathRapier
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBelt
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - GovernorDSM
+        - KnightDSM
+        - CourtierDSM
+        - TemplarDSM
+        - WealthDSM

--- a/Resources/Prototypes/_Crescent/Loadouts/Empire/items.yml
+++ b/Resources/Prototypes/_Crescent/Loadouts/Empire/items.yml
@@ -1,0 +1,39 @@
+- type: loadout
+  id: LoadoutItemDSMSabre
+  category: Items
+  cost: 4
+  items:
+    - DSMSabre
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDSMNobleWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - GovernorDSM
+        - KnightDSM
+        - CourtierDSM
+        - TemplarDSM
+        - WealthDSM
+
+- type: loadout
+  id: LoadoutItemDSMRapier
+  category: Items
+  cost: 4
+  items:
+    - DSMRapier
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDSMNobleWeapon
+    - !type:CharacterJobRequirement
+      jobs:
+        - AdjutantDSM
+        - AdvocatusDSM
+        - ArchmaesterDSM
+        - GovernorDSM
+        - KnightDSM
+        - CourtierDSM
+        - TemplarDSM
+        - WealthDSM

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/adjutant.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/adjutant.yml
@@ -83,6 +83,6 @@
     outerClothing: ClothingOuterCoatImperialAdjutant
     id: AdjutantPDA
     pocket1: ImperialPassportBareLegit
-    belt: WeaponRevolverSnubnose
+    pocket2: WeaponRevolverSnubnose
     ears: ClothingHeadsetEmpire
     gloves: ClothingHandsGlovesImperialAdjutantGloves

--- a/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
+++ b/Resources/Prototypes/_Crescent/Roles/Jobs/DSM/governor.yml
@@ -90,6 +90,5 @@
     shoes: ClothingShoesBootsImperialGovernorBoots
     head: ClothingHeadHatImperialBicorne
     outerClothing: ClothingOuterCoatImperialGovernor
-    belt: ClothingBeltSheathFilled
     id: GovernorPDA
     ears: ClothingHeadsetEmpire


### PR DESCRIPTION
# Description

Adds all of hullrot's backpacks and the DSM noble weapons and their sheathes to the loadout system for the higher ranking roles of the Mandate.

also moves or removes some roles' items that occupy the belt to allow the weapon sheath to spawn on the player equipped 
<h1>Media</h1>

https://github.com/user-attachments/assets/2c1c03c5-69d6-4bc6-a894-96471e00c723
